### PR TITLE
Feature: Add automation for multiplexer styles

### DIFF
--- a/roles/development/tasks/fonts.yml
+++ b/roles/development/tasks/fonts.yml
@@ -1,0 +1,27 @@
+---
+- name: Clone font repo
+  git:
+    repo: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized.git
+    dest: "{{ lookup('env', 'HOME') }}/.cache/fonts/SFMono-Nerd-Font-Ligaturized"
+    update: yes
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Install fonts
+  copy:
+    src: "{{ item }}"
+    dest: "{{ lookup('env', 'HOME') }}/.local/share/fonts/"
+  with_fileglob:
+    - "{{ lookup('env', 'HOME') }}/.cache/fonts/SFMono-Nerd-Font-Ligaturized/*.otf"
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Add font tap
+  homebrew_tap:
+    name: shaunsingh/SFMono-Nerd-Font-Ligaturized
+  when: ansible_facts["os_family"] == "Darwin"
+
+- name: Install font
+  homebrew_cask:
+    name:
+      - font-sf-mono-nerd-font-ligaturized
+    state: present
+  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -22,3 +22,4 @@
 - import_tasks: asdf.yml
 - import_tasks: tailscale.yml
 - import_tasks: tmux.yml
+- import_tasks: fonts.yml

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -21,3 +21,4 @@
 - import_tasks: vim.yml
 - import_tasks: asdf.yml
 - import_tasks: tailscale.yml
+- import_tasks: tmux.yml

--- a/roles/development/tasks/tmux.yml
+++ b/roles/development/tasks/tmux.yml
@@ -1,0 +1,8 @@
+- name: Install TPM
+  git: 
+    repo: https://github.com/tmux-plugins/tpm.git
+    dest: "{{ lookup('env', 'HOME') }}/.tmux/plugins/tpm"
+    update: no
+
+- name: Install plugins
+  shell: ~/.tmux/plugins/tpm/bin/install_plugins


### PR DESCRIPTION
With the migration to `nvim`, we're giving `tmux` a facelift so it doesn't stick out like a sore thumb.