### PR TITLE
Remove `authy` from desktop packages

### DIFF
--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -6,7 +6,6 @@
       - utm
       - alacritty
       - 1password
-      - authy
       - firefox
       - google-chrome
       - notion


### PR DESCRIPTION
As it says on the tin.