### PR TITLE
Fix development role provisioning on Debian

### DIFF
--- a/roles/development/tasks/asdf.yml
+++ b/roles/development/tasks/asdf.yml
@@ -8,10 +8,15 @@
     update: yes
 
 - name: Run Make
-  command: "{{ lookup('env', 'HOME') }}/.asdf make"
+  command: make
+  args:
+    chdir: "{{ lookup('env', 'HOME') }}/.asdf"
 
 - name: Copy asdf binary into $PATH
-  command: "{{ lookup('env', 'HOME') }}/.asdf cp asdf /usr/local/bin"
+  become: true
+  command: cp asdf /usr/local/bin
+  args:
+    chdir: "{{ lookup('env', 'HOME') }}/.asdf"
 
 - name: Install asdf plugins
   command: "{{ lookup('env', 'HOME') }}/.asdf/bin/asdf plugin-add {{ item }}"

--- a/roles/development/tasks/docker.yml
+++ b/roles/development/tasks/docker.yml
@@ -18,20 +18,19 @@
 - name: Add Docker's GPG key
   become: yes
   shell: |
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     chmod a+r /etc/apt/keyrings/docker.asc
   when: ansible_facts["os_family"] == "Debian"
 
 - name: Add Docker repository
+  become: yes
   shell: |
-    echo
-    'deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu
-    $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
   when: ansible_facts["os_family"] == "Debian"
 
 - name: Install Docker CE packages
   become: yes
-  package:
+  apt:
     name:
       - docker-ce
       - docker-ce-cli
@@ -39,4 +38,5 @@
       - docker-buildx-plugin
       - docker-compose-plugin
     state: present
+    update_cache: yes
   when: ansible_facts["os_family"] == "Debian"

--- a/roles/development/vars/packages.yml
+++ b/roles/development/vars/packages.yml
@@ -6,11 +6,11 @@ defaults: &defaults
   - tmux
   - ripgrep
   - neovim
-  - hurl
 
 families:
   darwin:
     - *defaults
+    - hurl
     - git
     - imagemagick
     - jq


### PR DESCRIPTION
Running `virtual-machine.yml` on a Debian 11 (bullseye) GitHub Codespace surfaced three Debian-target bugs in the `development` role. Each aborted the play at a different task; with these fixes the full playbook completes cleanly (`failed=0`) and installs zsh, asdf 0.18.0, Docker, Tailscale, and the rest of the toolchain.

## Fixes

| File | Problem | Fix |
|------|---------|-----|
| `roles/development/vars/packages.yml` | `hurl` lives in the shared `&defaults` anchor, but it's a Homebrew formula with no Debian apt package, so it aborted the whole apt batch (`No package matching 'hurl'`). | Moved `hurl` out of `&defaults` into the `darwin`-only list. |
| `roles/development/tasks/asdf.yml` | `command: "~/.asdf make"` tried to execute the `.asdf` **directory** as a program (`Permission denied`); the binary-copy step had the same shape. | Rewrote both steps with `chdir: ~/.asdf` and real `make` / `cp` commands (`become` for `/usr/local/bin`). |
| `roles/development/tasks/docker.yml` | The repo task emitted an **empty** `docker.list` (the `echo` was split across lines) and pointed at `/linux/ubuntu`, which has no `bullseye` suite (404), so `docker-ce` was never found. | Pointed the key and repo at `/linux/debian`, fixed the `echo` one-liner, and switched the install to the `apt` module with `update_cache: yes` so the new repo is seen in the same run. |

## Follow-up (not in this PR)

`roles/development/tasks/tailscale.yml` still hardcodes the Ubuntu `groovy` apt repo. It installed successfully on bullseye, but it's the same Debian-vs-Ubuntu mismatch and is worth pointing at the Debian repo too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)